### PR TITLE
Implement --test-name option

### DIFF
--- a/Turkey/Program.cs
+++ b/Turkey/Program.cs
@@ -37,12 +37,20 @@ namespace Turkey
             Arity = ArgumentArity.ZeroOrMore
         };
 
+        public static readonly Option<IEnumerable<string>> testsOption = new Option<IEnumerable<string>>(
+            new string[] { "--test-name" },
+            "Run specific tests within the test root directory.")
+        {
+            Arity = ArgumentArity.OneOrMore
+        };
+
         public static async Task<int> Run(string testRoot,
                                           bool verbose,
                                           string logDirectory,
                                           string additionalFeed,
                                           IEnumerable<string> trait,
-                                          int timeout)
+                                          int timeout,
+                                          IEnumerable<string> testName)
         {
             TimeSpan defaultTimeout;
             if (timeout == 0)
@@ -132,7 +140,7 @@ namespace Turkey
                 verboseOutput: verbose,
                 nuGetConfig: nuGetConfig);
 
-            var results = await runner.ScanAndRunAsync(testOutputs, logDir.FullName, defaultTimeout);
+            var results = await runner.ScanAndRunAsync(testOutputs, logDir.FullName, defaultTimeout, testName);
 
             int exitCode = (results.Failed == 0) ? 0 : 1;
             return exitCode;
@@ -260,6 +268,7 @@ namespace Turkey
             rootCommand.AddOption(additionalFeedOption);
             rootCommand.AddOption(traitOption);
             rootCommand.AddOption(timeoutOption);
+            rootCommand.AddOption(testsOption);
 
             return await rootCommand.InvokeAsync(args);
         }

--- a/Turkey/TestRunner.cs
+++ b/Turkey/TestRunner.cs
@@ -69,7 +69,7 @@ namespace Turkey
             this.nuGetConfig = nuGetConfig;
         }
 
-        public async Task<TestResults> ScanAndRunAsync(List<TestOutput> outputs, string logDir, TimeSpan defaultTimeout)
+        public async Task<TestResults> ScanAndRunAsync(List<TestOutput> outputs, string logDir, TimeSpan defaultTimeout, IEnumerable<string> tests)
         {
 
             await outputs.ForEachAsync(output => output.AtStartupAsync());
@@ -86,9 +86,14 @@ namespace Turkey
             TestParser parser = new TestParser();
 
             // sort tests before running to keep test order the same everywhere
-            var sortedFiles = root
+            IEnumerable<FileInfo> sortedFiles = root
                 .EnumerateFiles("test.json", options)
                 .OrderBy(f => f.DirectoryName);
+
+            if (tests.Any())
+            {
+                sortedFiles = sortedFiles.Where(f => tests.Contains(f.Directory.Name));
+            }
 
             foreach (var file in sortedFiles)
             {


### PR DESCRIPTION
This PR re-targets both projects in the solution to `net8.0`.

It also implements the `--tests` option to the test runner, which allows a user to specify which tests in the current directory they want to run. If no tests are specified, the default behavior is maintained and all tests are run.