### PR TITLE
Upgraded NuGet packages and removed deprecated ones

### DIFF
--- a/Turkey.Tests/Turkey.Tests.csproj
+++ b/Turkey.Tests/Turkey.Tests.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Turkey/Turkey.csproj
+++ b/Turkey/Turkey.csproj
@@ -12,11 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21573.1" />
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6" />
-    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6" />
-    <PackageReference Include="Text.Analyzers" Version="2.6" />
+    <PackageReference Include="Text.Analyzers" Version="3.3.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR upgrades NuGet package versions for both the `Turkey` and the `Turkey.Tests` projects.

This was necessary for the following reasons:

- `Microsoft.NET.Test.Sdk` had an older version that did not recognize `Ppc64le` as a valid architecture in the [PlatformEnvironment implementation](https://github.com/microsoft/vstest/blob/c6ed8f50ab00dc5c6877fc0926573c9b010eceb5/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformEnvironment.cs#L17). Because of that, the autopkgtests for the ppc64el .NET 8 package were failing with a `NotSupportedException` (see [log](https://autopkgtest.ubuntu.com/results/autopkgtest-noble-mateus-morais-dotnet8-ppc64el-ppa/noble/ppc64el/d/dotnet8/20240430_182011_99c86@/log.gz)).
- `Microsoft.CodeQuality.Analyzers` and `Microsoft.NetCore.Analyzers` are deprecated. Analyzers are now implemented in the .NET SDK since .NET 5 and Visual Studio 2019 16.8 (see [documentation](https://learn.microsoft.com/en-us/visualstudio/code-quality/migrate-from-fxcop-analyzers-to-net-analyzers)). These packages have been removed.
- Other packages had newer versions available, so they were upgraded accordingly.
- Leaving `System.CommandLine` unchanged at the moment since it introduces breaking changes.